### PR TITLE
Update NUMBER.MaxRateValue.md

### DIFF
--- a/param-docs/parameter-pages/PostProcessing/NUMBER.MaxRateValue.md
+++ b/param-docs/parameter-pages/PostProcessing/NUMBER.MaxRateValue.md
@@ -1,5 +1,5 @@
 # Parameter `<NUMBER>.MaxRateValue`
-Default Value: `0.05`
+Default Value: `0,05`
 
 Maximum change of a reading.
 Depending on the settings of `<NUMBER>.MaxRateType` it is either treated  as `absolute` or `relative`!


### PR DESCRIPTION
The decimal separator used is actually a comma not a point. The code handles an input using a point as the separator and changes the separator to  a comma: e.g. 0.05 input to 0,05. 

I suggest adding an example for absolute and relative changes, probably 0,05 would mean a 5% change if set to relative? What would be the use case for setting the MaxRateType to relative?